### PR TITLE
Fix shadowed name warnings

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,5 +23,8 @@
     "purescript-test-unit": "^10.0.1",
     "purescript-psci-support": "^2.0.0",
     "purescript-flaredoc": "^2.0.0"
+  },
+  "resolutions": {
+    "purescript-dom": "^3.1.0"
   }
 }

--- a/src/Color.purs
+++ b/src/Color.purs
@@ -322,8 +322,8 @@ toXYZ c = { x, y, z }
     g = finv rec.g
     b = finv rec.b
 
-    finv c | c <= 0.04045 = c / 12.92
-           | otherwise    = ((c + 0.055) / 1.055) `pow` 2.4
+    finv c' | c' <= 0.04045 = c' / 12.92
+            | otherwise     = ((c' + 0.055) / 1.055) `pow` 2.4
 
 -- | Get L, a and b coordinates according to the Lab color space.
 -- |

--- a/src/Color/Scale.purs
+++ b/src/Color/Scale.purs
@@ -191,7 +191,7 @@ cssColorStops scale@(ColorScale _ b middle e) = cssColorStops csRGB
     csRGB' = ColorScale RGB b middle e
 
     csRGB = foldl addStop' csRGB' additionalStops
-    addStop' scale (ColorStop c r) = addStop scale c r
+    addStop' scale' (ColorStop c r) = addStop scale' c r
 
     additionalStops = do
       step <- 1 .. 9


### PR DESCRIPTION
Also had to add a resolution to the `bower.json` since it seems some of the dev dependencies are using `~` ranges instead of `^`.