### PR TITLE
Allow 360 as Hue

### DIFF
--- a/src/Color.purs
+++ b/src/Color.purs
@@ -165,7 +165,7 @@ rgb' r g b = rgba' r g b 1.0
 -- | lightness and alpha are numbers between 0.0 and 1.0.
 hsla :: Number -> Number -> Number -> Number -> Color
 hsla h s l a = HSLA h' s' l' a'
-  where h' = h `modPos` 360.0
+  where h' = if h == 360.0 then h else h `modPos` 360.0
         s' = clamp 0.0 1.0 s
         l' = clamp 0.0 1.0 l
         a' = clamp 0.0 1.0 a


### PR DESCRIPTION
Currently we can't have `hsl(360, 100%, 50%)` with this PR it's allowed value. 

I could have updated `modPos`:
```purescript
modPos :: Number -> Number -> Number
modPos x y | x == y = y
modPos x y = (x % y + y) % y
```

But don't know if it would correct for it's usage in here:
```
hue' c | maxChroma == red   = ((g - b) / chroma') `modPos` 6.0
```
